### PR TITLE
[#77]カードコンポーネントの調整

### DIFF
--- a/src/components/MediaCard.tsx
+++ b/src/components/MediaCard.tsx
@@ -1,35 +1,33 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import Card from '@mui/material/Card';
-import CardActions from '@mui/material/CardActions';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 
 export default function MediaCard({ heading, text, href, imgSrc, imgAlt }: { heading: string; text: string, href: string, imgSrc: string, imgAlt: string }) {
   return (
-    <Card>
-      <Image
-        alt={imgAlt}
-        src={imgSrc}
-        width={640}
-        height={480}
-        style={{
-          maxWidth: '100%',
-          height: '200px',
-          objectFit: 'cover',
-        }}
-      />
-      <CardContent>
-        <Typography gutterBottom variant="h5" component="div">
-          {heading}
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          {text}
-        </Typography>
-      </CardContent>
-      <CardActions>
-        <Link href={href}>詳細</Link>
-      </CardActions>
-    </Card>
+    <Link href={href}>
+      <Card>
+        <Image
+          alt={imgAlt}
+          src={imgSrc}
+          width={640}
+          height={480}
+          style={{
+            maxWidth: '100%',
+            height: '200px',
+            objectFit: 'cover',
+          }}
+        />
+        <CardContent>
+          <Typography gutterBottom variant="h5" component="div">
+            {heading}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {text}
+          </Typography>
+        </CardContent>
+      </Card>
+    </Link>
   );
 }


### PR DESCRIPTION
![スクリーンショット 2024-06-18 23 00 02](https://github.com/yutaroud/rect/assets/50858023/824d9c1c-5a0b-4e1e-9bf0-8f6efeb38c7f)

- まるっとaタグにした
- ただのnextのLinkなので、MUIのLinkコンポーネントは使えない