### PR TITLE
[#117]ページ内遷移が適切にできるように修正

### DIFF
--- a/src/app/Header.tsx
+++ b/src/app/Header.tsx
@@ -1,3 +1,4 @@
+"use client";
 import AppBar from "@mui/material/AppBar";
 import Toolbar from "@mui/material/Toolbar";
 import Link from "next/link";
@@ -5,18 +6,21 @@ import Box from "@mui/material/Box";
 import Image from "next/image";
 import logoRectImg from "../../public/image/top/logo_rect.png";
 import logoReprosImg from "../../public/image/school/logo.png";
+import { usePathname } from 'next/navigation';
 
 interface HeaderProps {
-  switchLogo?: boolean;
+  isSchoolPage?: boolean;
 }
 
-const Header: React.FC<HeaderProps> = ({ switchLogo }) => {
+const Header: React.FC<HeaderProps> = () => {
+  const pathname = usePathname();
+  const isSchoolPage = pathname.includes('/school');
   return (
     <AppBar
       position="sticky"
       sx={{ top: 0, boxShadow: "none", background: "none" }}
     >
-      {switchLogo ? (
+      {isSchoolPage ? (
         <Toolbar sx={{ backgroundColor: "#fff" }}>
           <Box style={{ width: "420px", display: "flex" }}>
             <Link href="/school">

--- a/src/app/Header.tsx
+++ b/src/app/Header.tsx
@@ -13,8 +13,8 @@ interface HeaderProps {
 const Header: React.FC<HeaderProps> = ({ switchLogo }) => {
   return (
     <AppBar
-      position="fixed"
-      sx={{ zIndex: 2000, boxShadow: "none", background: "none" }}
+      position="sticky"
+      sx={{ top: 0, boxShadow: "none", background: "none" }}
     >
       {switchLogo ? (
         <Toolbar sx={{ backgroundColor: "#fff" }}>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -79,10 +79,13 @@
   margin: 0;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 html,
 body {
   max-width: 100vw;
-  overflow-x: hidden;
 }
 
 a {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,3 @@
-import Head from "next/head";
-import Header from "./Header";
 import ThemeRegistry from "@/components/ThemeRegistry/ThemeRegistry";
 import Footer from "./Footer";
 import { GoogleTagManager } from "@next/third-parties/google";
@@ -20,7 +18,6 @@ export default function RootLayout({
       <GoogleTagManager gtmId="GTM-MRQP5SQ2" />
       <body>
         <ThemeRegistry>
-          <Header />
           {children}
           <Footer />
         </ThemeRegistry>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import Header from "./Header";
 import ThemeRegistry from "@/components/ThemeRegistry/ThemeRegistry";
 import Footer from "./Footer";
 import { GoogleTagManager } from "@next/third-parties/google";
@@ -18,6 +19,7 @@ export default function RootLayout({
       <GoogleTagManager gtmId="GTM-MRQP5SQ2" />
       <body>
         <ThemeRegistry>
+          <Header />
           {children}
           <Footer />
         </ThemeRegistry>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,7 +19,6 @@ export const metadata = {
 export default function Home() {
   return (
     <main style={{paddingBottom: "80px"}}>
-      <Header />
       <Kv />
       <Business />
       <Company />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+import Head from "next/head";
+import Header from "./Header";
 import "./globals.css";
 import Kv from "../modules/Kv";
 import Company from "../modules/Company";
@@ -17,6 +19,7 @@ export const metadata = {
 export default function Home() {
   return (
     <main style={{paddingBottom: "80px"}}>
+      <Header />
       <Kv />
       <Business />
       <Company />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,3 @@
-import Head from "next/head";
-import Header from "./Header";
 import "./globals.css";
 import Kv from "../modules/Kv";
 import Company from "../modules/Company";

--- a/src/app/school/Introduction.tsx
+++ b/src/app/school/Introduction.tsx
@@ -3,6 +3,7 @@ import Typography from "@mui/material/Typography";
 import headingTeacherImg from "../../../public/image/school/heading_introduction.png";
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
+import Link from "next/link";
 
 const sxStyles = {
   textWrap: {
@@ -65,6 +66,20 @@ const sxStyles = {
       aspectRatio: 1,
       padding: 0,
     },
+  },
+  textLink: {
+    textDecoration: 'underline',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 0.5,
+    '&:after' : {
+      content : '""',
+      width: 0,
+      height: 0,
+      borderLeft: '6px solid transparent',
+      borderRight: '6px solid transparent',
+      borderTop: '6px solid black',
+    }
   }
 };
 
@@ -110,6 +125,11 @@ const Introduction = () => {
               最新の業界動向や実践的なスキルを<br/>
               直接学ぶことができます。<br/>
               現場での経験を基にした実践的な指導が特徴です。
+            </Typography>
+            <Typography variant="body2" mt={2} sx={sxStyles.textLink}>
+              <Link href="#school_teacher">
+                  講師について詳しく見る
+              </Link>
             </Typography>
           </Box>
         </Box>

--- a/src/app/school/Teacher.tsx
+++ b/src/app/school/Teacher.tsx
@@ -5,7 +5,7 @@ import iconImg from "../../../public/image/school/icon.png";
 
 const Teacher = () => {
   return (
-    <Box pt={6} pb={10} mx={3}>
+    <Box pt={6} pb={10} mx={3} id="school_teacher">
       <Typography variant="h2">
         <img src={headingTeacherImg.src} alt="講師" width="58" />
       </Typography>

--- a/src/app/school/page.tsx
+++ b/src/app/school/page.tsx
@@ -22,7 +22,6 @@ const School = () => {
       <Header switchLogo={true} />
       <Box
         component="section"
-        mt={7}
         sx={{
           textAlign: "center",
           mx: "auto",

--- a/src/app/school/page.tsx
+++ b/src/app/school/page.tsx
@@ -19,7 +19,6 @@ export const metadata = {
 const School = () => {
   return (
     <main>
-      <Header switchLogo={true} />
       <Box
         component="section"
         sx={{

--- a/src/modules/Kv.tsx
+++ b/src/modules/Kv.tsx
@@ -8,7 +8,6 @@ const Kv = () => {
   return (
     <>
     <Box
-      mt={8}
       sx={{
         textAlign: "center",
         "@media screen and (max-width:800px)": {
@@ -26,7 +25,6 @@ const Kv = () => {
       </Fade>
     </Box>
     <Box
-      mt={8}
       sx={{
         display: "none",
         "@media screen and (max-width:800px)": {


### PR DESCRIPTION
# PR Title

Closes <!-- github ticket number, e.g., #32 -->

## Description

- ヘッダーの固定の仕方を `position: stikcy` に変更
    - ページ内遷移する時、fixedだとヘッダーの高さを持っていないので、ヘッダーの高さ分コンテンツがずれてスクロールしてしまう
        - stickyだと、ヘッダーの高さを持っているので、スクロールした時にちょうどぴったりの位置に
        - 参考： [headerをフロートする | positionプロパティを身に着けよう！stickyの仕様と使い方を解説！](https://www.asobou.co.jp/blog/web/css-sticky#:~:text=%E3%81%8D%E3%81%BE%E3%81%97%E3%82%87%E3%81%86%E3%80%82-,header%E3%82%92%E3%83%95%E3%83%AD%E3%83%BC%E3%83%88%E3%81%99%E3%82%8B,-%E3%81%93%E3%82%8C%E3%81%8C%E4%B8%80%E8%88%AC)
    - stickyにしたので、ヘッダー直下のコンテンツにmargin-topがいらなくなった。削除
- ヘッダーが2つあったので、1つに変更
    - Layout.tsxとpages.tsxと2回呼んでいるので、1回になるよう調整
- 「講師について詳しく見る」テキストリンク追加
    - 講師コンテンツにスクロールする

## Screenshot

||before|after|
|---|---|---|
|ヘッダー|<img width="709" alt="スクリーンショット 2024-11-05 23 26 35" src="https://github.com/user-attachments/assets/b88bf52b-ab6a-47b7-b3a2-2844ec997ef9">|<img width="505" alt="スクリーンショット 2024-11-05 23 25 38" src="https://github.com/user-attachments/assets/7def80c4-57a7-4fa0-9906-e076d4f59077">|
|特徴コンテンツ|<img width="436" alt="スクリーンショット 2024-11-05 23 24 51" src="https://github.com/user-attachments/assets/52c1e0a0-0af4-46e0-86d3-b8e023c5fa39">|<img width="439" alt="スクリーンショット 2024-11-05 23 24 29" src="https://github.com/user-attachments/assets/8b877ff1-b65c-46df-8320-08cd4315bb27">|


### 意図せぬ崩れなし

|TOP|プログラミング教室|
|---|---|
<img width="453" alt="スクリーンショット 2024-11-05 23 28 12" src="https://github.com/user-attachments/assets/fcb2ba55-93d0-4bd5-a007-847d381063f4">|<img width="441" alt="スクリーンショット 2024-11-05 23 28 20" src="https://github.com/user-attachments/assets/285c045f-7db0-460f-ba30-7bc8d70f59be">|


## Steps to Verify

Please walk through how to verify and test this feature or fix.
