### PR TITLE
[#127]コース詳細ページのtitleタグ変更

### DIFF
--- a/src/app/school/[courseSlug]/page.tsx
+++ b/src/app/school/[courseSlug]/page.tsx
@@ -12,9 +12,27 @@ export async function generateStaticParams() {
   }));
 }
 
+export async function generateMetadata({ params }: CoursePageProps) {
+  const course = Courses.find((course) => course.slug === params.courseSlug);
+
+  if (!course) {
+    return {
+      title: "コースが見つかりません | プログラミングを学ぶならRe:ProS(レプロス)",
+    };
+  }
+
+  return {
+    title: `${course.name.category} ${course.name.level}コース | プログラミングを学ぶならRe:ProS(レプロス)`,
+  };
+}
+
 interface CoursePageProps {
   params: {
     courseSlug: string;
+    name: {
+      category: string;
+      level: string;
+    };
   };
 }
 


### PR DESCRIPTION
# PR Title

Closes #127 

## Description

- コース詳細ページのtitleタグを変更する

## Screenshot

||before|after|
|---|---|---|
| https://re-ct.co.jp/school/scratch-beginner/|<img width="254" alt="スクリーンショット 2024-11-21 0 13 58" src="https://github.com/user-attachments/assets/c1aee5cf-6a68-4270-8cc1-84bba744948d">|<img width="300" alt="スクリーンショット 2024-11-21 0 12 55" src="https://github.com/user-attachments/assets/7bf7fef1-943c-4077-b863-7b8da3821ee0"><img width="333" alt="スクリーンショット 2024-11-21 0 12 58" src="https://github.com/user-attachments/assets/b3715774-7470-41fb-9fc6-69b14a0f923e">|


## Steps to Verify

Please walk through how to verify and test this feature or fix.
