### PR TITLE
同ドメインは同じタブで開くよう修正

### DIFF
--- a/src/app/announcement/Post.tsx
+++ b/src/app/announcement/Post.tsx
@@ -61,7 +61,6 @@ const list = Announcement.map((post) => (
         link={{
           href: post.link,
           external: false,
-          newTab: true,
         }}
       >
         <time

--- a/src/components/Footer/CareerFooter.tsx
+++ b/src/components/Footer/CareerFooter.tsx
@@ -67,7 +67,6 @@ const CareerFooter = () => {
             link={{
               href: '/',
               external: false,
-              newTab: true,
             }}
           >
             運営会社
@@ -84,7 +83,6 @@ const CareerFooter = () => {
             link={{
               href: '/privacy',
               external: false,
-              newTab: true,
             }}
           >
             プライバシーポリシー
@@ -93,7 +91,6 @@ const CareerFooter = () => {
             link={{
               href: '/announcement',
               external: false,
-              newTab: true,
             }}
           >
             電子公告

--- a/src/components/Footer/SchoolFooter.tsx
+++ b/src/components/Footer/SchoolFooter.tsx
@@ -106,7 +106,6 @@ const SchoolFooter = () => {
     {
       text: 'Re:ProS フランチャイズオーナー募集サイト',
       href: '/school/fc/',
-      external: true,
     },
   ];
   return (
@@ -150,7 +149,6 @@ const SchoolFooter = () => {
                 link={{
                   href: '/',
                   external: false,
-                  newTab: true,
                 }}
               >
                 運営会社
@@ -167,7 +165,6 @@ const SchoolFooter = () => {
                 link={{
                   href: '/privacy/',
                   external: false,
-                  newTab: true,
                 }}
               >
                 プライバシーポリシー
@@ -176,7 +173,6 @@ const SchoolFooter = () => {
                 link={{
                   href: '/announcement/',
                   external: false,
-                  newTab: true,
                 }}
               >
                 電子公告

--- a/src/modules/Business.tsx
+++ b/src/modules/Business.tsx
@@ -176,7 +176,7 @@ const Business = () => {
                   key={item.id}
                   onMouseEnter={() => setHoveredId(item.id)}
                 >
-                  <Link href={item.href} target="_blank" rel="noopener">
+                  <Link href={item.href}>
                     <Box
                       component="img"
                       key={item.id}


### PR DESCRIPTION
# PR Title

Closes #228 

## Description

- フッターのリンクで、同リポジトリのものが同タブで開く
    - <img width="1326" height="360" alt="スクリーンショット 2026-04-06 11 04 30" src="https://github.com/user-attachments/assets/2d99ad17-2398-433d-83a3-4d6d462d8215" />
    -<img width="1094" height="329" alt="スクリーンショット 2026-04-06 11 04 41" src="https://github.com/user-attachments/assets/61f2230b-3117-4a6a-9a2d-defd100bf31c" />
- /demand/develop、demand/ad の会社概要が同じタブで開く
    - <img width="1316" height="425" alt="スクリーンショット 2026-04-06 11 04 32" src="https://github.com/user-attachments/assets/1c71265c-4b44-41b5-9e34-ff3555add6cd" />
- 会社TOPのサービス概要も、同じタブで開く
    - <img width="995" height="558" alt="スクリーンショット 2026-04-06 11 08 45" src="https://github.com/user-attachments/assets/5818723c-adfc-49f6-ab35-2317941ca695" />
- 電子広告のpdfが同じタブで開く
     - <img width="1114" height="240" alt="スクリーンショット 2026-04-06 11 09 24" src="https://github.com/user-attachments/assets/2c0892e6-b027-4142-afb6-2df9f2bdd3b9" />


## grep

- commonLinkコンポーネントでは利用なし
     - <img width="374" height="307" alt="スクリーンショット 2026-04-06 11 00 49" src="https://github.com/user-attachments/assets/cf5e7fef-c0bb-4a6f-af6d-79192a2fdd9c" />
- 他の_blankは外部リンクなことを確認
    - <img width="812" height="603" alt="スクリーンショット 2026-04-06 11 10 13" src="https://github.com/user-attachments/assets/b53d6e3a-2010-497f-a6e7-1e4cf2352f87" />

## Steps to Verify

Please walk through how to verify and test this feature or fix.
